### PR TITLE
Make the router more dynamic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .idea
-.env
-development.env
 bin/
+*.env
+!.env.sample

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ source := ./cmd/push/main.go
 .PHONY: build
 build: clean
 	@echo "Building the application..."
-	go build -o $(build_dir)/push $(source)
+	go build -gcflags="all=-N -l" -o $(build_dir)/push $(source)
 
 .PHONY: run
 run: build
 	@echo "Running the application with argument: $(env)"
-	$(build_dir)/push $(env)
+	dlv --listen=:40000 --headless=true --api-version=2 exec ./$(build_dir)/push $(env)
 
 .PHONY: clean
 clean:

--- a/cmd/push/main.go
+++ b/cmd/push/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/Ayano2000/push/internal/config"
 	"github.com/Ayano2000/push/internal/handlers"
-	"github.com/Ayano2000/push/internal/routes"
+	"github.com/Ayano2000/push/internal/router"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/rs/zerolog/pkgerrors"
@@ -37,20 +37,15 @@ func main() {
 
 	defer handler.Services.Cleanup()
 
-	dmux, err := routes.RegisterRoutes(handler)
+	dmux, err := router.RegisterRoutes(handler)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to register routes: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Unable to register router: %v\n", err)
 		os.Exit(1)
 	}
 
-	wrapper := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := context.WithValue(r.Context(), "mux", dmux)
-		dmux.ServeHTTP(w, r.WithContext(ctx))
-	})
-
 	server := http.Server{
 		Addr:    conf.ServerAddress,
-		Handler: wrapper,
+		Handler: dmux,
 	}
 
 	fmt.Fprintf(os.Stdout, "Server is running on: %s", conf.ServerAddress)

--- a/internal/pkg/minio/minio.go
+++ b/internal/pkg/minio/minio.go
@@ -2,6 +2,7 @@ package minio
 
 import (
 	"context"
+	"fmt"
 	"github.com/Ayano2000/push/internal/config"
 	"github.com/Ayano2000/push/internal/types"
 	"github.com/google/uuid"
@@ -60,7 +61,7 @@ func (m *Minio) PutObject(ctx context.Context, webhook types.Webhook, payload st
 	_, err = m.Client.PutObject(
 		ctx,
 		webhook.Name,
-		uid.String(),
+		fmt.Sprintf("%s.json", uid.String()),
 		io.NopCloser(strings.NewReader(payload)),
 		int64(len(payload)),
 		minio.PutObjectOptions{

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -102,3 +102,5 @@ func RegisterRoutes(handler *handlers.Handler) (*Router, error) {
 
 	return dmux, nil
 }
+
+var _ types.WebhookRegistrar = (*Router)(nil)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,4 +1,4 @@
-package routes
+package router
 
 import (
 	"context"
@@ -9,17 +9,20 @@ import (
 	"sync"
 )
 
-const PatternString = "%s %s"
+const (
+	PatternString                     = "%s %s"
+	muxContextKey types.MuxContextKey = "router"
+)
 
-type DynamicMux struct {
+type Router struct {
 	mutex      sync.RWMutex
 	routes     map[string]http.HandlerFunc
 	handler    *handlers.Handler
 	middleware []func(http.HandlerFunc) http.HandlerFunc
 }
 
-func NewDynamicMux(handler *handlers.Handler) *DynamicMux {
-	return &DynamicMux{
+func NewDynamicMux(handler *handlers.Handler) *Router {
+	return &Router{
 		routes:     make(map[string]http.HandlerFunc),
 		handler:    handler,
 		middleware: make([]func(http.HandlerFunc) http.HandlerFunc, 0),
@@ -27,7 +30,7 @@ func NewDynamicMux(handler *handlers.Handler) *DynamicMux {
 }
 
 // HandleFunc registers a new route with its handler function
-func (dmux *DynamicMux) HandleFunc(pattern string, handler http.HandlerFunc) {
+func (dmux *Router) HandleFunc(pattern string, handler http.HandlerFunc) {
 	dmux.mutex.Lock()
 	defer dmux.mutex.Unlock()
 
@@ -35,7 +38,7 @@ func (dmux *DynamicMux) HandleFunc(pattern string, handler http.HandlerFunc) {
 }
 
 // RegisterWebhook adds a new webhook route dynamically
-func (dmux *DynamicMux) RegisterWebhook(webhook types.Webhook) {
+func (dmux *Router) RegisterWebhook(webhook types.Webhook) {
 	pattern := fmt.Sprintf(PatternString, webhook.Method, webhook.Path)
 	dmux.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
 		dmux.handler.HandleMessage(w, r, webhook)
@@ -43,7 +46,7 @@ func (dmux *DynamicMux) RegisterWebhook(webhook types.Webhook) {
 }
 
 // ServeHTTP implements the http.Handler interface
-func (dmux *DynamicMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (dmux *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	dmux.mutex.RLock()
 	pattern := fmt.Sprintf(PatternString, r.Method, r.URL.Path)
 	handler, exists := dmux.routes[pattern]
@@ -53,27 +56,33 @@ func (dmux *DynamicMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	handler(w, r)
+
+	ctx := context.WithValue(r.Context(), muxContextKey, dmux)
+	r = r.WithContext(ctx)
+
+	// Apply middleware to the handler if any
+	handlerWithMiddleware := dmux.applyMiddleware(handler)
+	handlerWithMiddleware(w, r)
 }
 
 // Use appends the given functions to middleware
-func (dmux *DynamicMux) Use(middleware ...func(http.HandlerFunc) http.HandlerFunc) {
+func (dmux *Router) Use(middleware ...func(http.HandlerFunc) http.HandlerFunc) {
 	dmux.middleware = append(dmux.middleware, middleware...)
 }
 
 // applyMiddleware will invoke the dmux.middleware functions in reverse order
 // so the first middleware in the chain is the outermost wrapper
-func (dmux *DynamicMux) applyMiddleware(handler http.HandlerFunc) http.HandlerFunc {
+func (dmux *Router) applyMiddleware(handler http.HandlerFunc) http.HandlerFunc {
 	for i := len(dmux.middleware) - 1; i >= 0; i-- {
 		handler = dmux.middleware[i](handler)
 	}
 	return handler
 }
 
-func RegisterRoutes(handler *handlers.Handler) (*DynamicMux, error) {
+func RegisterRoutes(handler *handlers.Handler) (*Router, error) {
 	dmux := NewDynamicMux(handler)
 
-	// Register static routes
+	// Register static router
 	dmux.HandleFunc("POST /webhooks", handler.CreateWebhook)
 	dmux.HandleFunc("GET /webhooks", handler.GetWebhooks)
 	dmux.HandleFunc("GET /webhooks/{name}/content", handler.GetWebhookContent)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -6,27 +6,84 @@ import (
 	"github.com/Ayano2000/push/internal/handlers"
 	"github.com/Ayano2000/push/internal/types"
 	"net/http"
+	"strings"
 	"sync"
 )
 
 const (
-	PatternString                     = "%s %s"
-	muxContextKey types.MuxContextKey = "router"
+	PatternString                               = "%s %s"
+	muxContextKey      types.MuxContextKey      = "router"
+	urlParamContextKey types.UrlParamContextKey = "parameters"
 )
 
 type Router struct {
-	mutex      sync.RWMutex
-	routes     map[string]http.HandlerFunc
-	handler    *handlers.Handler
-	middleware []func(http.HandlerFunc) http.HandlerFunc
+	mutex         sync.RWMutex
+	staticRoutes  map[string]*Route
+	dynamicRoutes []*Route
+	handler       *handlers.Handler
+	middleware    []func(http.HandlerFunc) http.HandlerFunc
+}
+
+type Route struct {
+	pattern    string
+	parameters []string
+	segments   []string
+	handler    http.HandlerFunc
+	isDynamic  bool
 }
 
 func NewDynamicMux(handler *handlers.Handler) *Router {
 	return &Router{
-		routes:     make(map[string]http.HandlerFunc),
-		handler:    handler,
-		middleware: make([]func(http.HandlerFunc) http.HandlerFunc, 0),
+		staticRoutes:  make(map[string]*Route),
+		dynamicRoutes: make([]*Route, 0),
+		handler:       handler,
+		middleware:    make([]func(http.HandlerFunc) http.HandlerFunc, 0),
 	}
+}
+
+// parsePattern extracts parameter names and segments from a URL pattern
+func parsePattern(pattern string) (parameters []string, segments []string, isDynamic bool) {
+	parts := strings.Split(pattern, "/")
+
+	for _, part := range parts {
+		if strings.HasPrefix(part, "{") && strings.HasSuffix(part, "}") {
+			name := strings.Trim(part, "{}")
+			parameters = append(parameters, name)
+			segments = append(segments, "*")
+			isDynamic = true
+		} else {
+			segments = append(segments, part)
+		}
+	}
+
+	return parameters, segments, isDynamic
+}
+
+func matchRoute(route *Route, method string, path string) (map[string]string, bool) {
+	pathParts := strings.Split(path, "/")
+
+	if len(pathParts) != len(route.segments) {
+		return nil, false
+	}
+
+	params := make(map[string]string)
+	paramIndex := 0
+
+	for i, segment := range route.segments {
+		if segment == "*" {
+			params[route.parameters[paramIndex]] = pathParts[i]
+			paramIndex++
+		} else if segment != pathParts[i] {
+			return nil, false
+		}
+	}
+
+	routeMethod := strings.Split(route.pattern, " ")[0]
+	if method != routeMethod {
+		return nil, false
+	}
+
+	return params, true
 }
 
 // HandleFunc registers a new route with its handler function
@@ -34,7 +91,24 @@ func (dmux *Router) HandleFunc(pattern string, handler http.HandlerFunc) {
 	dmux.mutex.Lock()
 	defer dmux.mutex.Unlock()
 
-	dmux.routes[pattern] = handler
+	parts := strings.Split(pattern, " ")
+	if len(parts) != 2 {
+		panic("invalid pattern: " + pattern)
+	}
+	parameters, segments, isDynamic := parsePattern(parts[1])
+	route := &Route{
+		pattern:    pattern,
+		parameters: parameters,
+		segments:   segments,
+		handler:    handler,
+		isDynamic:  isDynamic,
+	}
+
+	if isDynamic {
+		dmux.dynamicRoutes = append(dmux.dynamicRoutes, route)
+	} else {
+		dmux.staticRoutes[pattern] = route
+	}
 }
 
 // RegisterWebhook adds a new webhook route dynamically
@@ -48,21 +122,27 @@ func (dmux *Router) RegisterWebhook(webhook types.Webhook) {
 // ServeHTTP implements the http.Handler interface
 func (dmux *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	dmux.mutex.RLock()
-	pattern := fmt.Sprintf(PatternString, r.Method, r.URL.Path)
-	handler, exists := dmux.routes[pattern]
 	dmux.mutex.RUnlock()
 
-	if !exists {
-		http.NotFound(w, r)
+	pattern := fmt.Sprintf(PatternString, r.Method, r.URL.Path)
+	if route, exists := dmux.staticRoutes[pattern]; exists {
+		ctx := context.WithValue(r.Context(), muxContextKey, dmux)
+		r = r.WithContext(ctx)
+		dmux.applyMiddleware(route.handler)(w, r)
 		return
 	}
 
-	ctx := context.WithValue(r.Context(), muxContextKey, dmux)
-	r = r.WithContext(ctx)
+	for _, route := range dmux.dynamicRoutes {
+		if params, ok := matchRoute(route, r.Method, r.URL.Path); ok {
+			ctx := context.WithValue(r.Context(), muxContextKey, dmux)
+			ctx = context.WithValue(ctx, urlParamContextKey, params)
+			r = r.WithContext(ctx)
+			dmux.applyMiddleware(route.handler)(w, r)
+			return
+		}
+	}
 
-	// Apply middleware to the handler if any
-	handlerWithMiddleware := dmux.applyMiddleware(handler)
-	handlerWithMiddleware(w, r)
+	http.NotFound(w, r)
 }
 
 // Use appends the given functions to middleware

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -6,28 +6,87 @@ import (
 	"github.com/Ayano2000/push/internal/handlers"
 	"github.com/Ayano2000/push/internal/types"
 	"net/http"
+	"sync"
 )
 
-func RegisterRoutes(mux *http.ServeMux, handler *handlers.Handler) error {
-	mux.HandleFunc("POST /webhooks", handler.CreateWebhook)
-	mux.HandleFunc("GET /webhooks", handler.GetWebhooks)
-	mux.HandleFunc("GET /webhooks/{name}/content", handler.GetWebhookContent)
-	mux.HandleFunc("DELETE /webhooks/{name}", handler.DeleteWebhook)
-	mux.HandleFunc("DELETE /webhooks/{name}/content", handler.DeleteWebhookContents)
+const PatternString = "%s %s"
 
-	// custom endpoints
+type DynamicMux struct {
+	mutex      sync.RWMutex
+	routes     map[string]http.HandlerFunc
+	handler    *handlers.Handler
+	middleware []func(http.HandlerFunc) http.HandlerFunc
+}
+
+func NewDynamicMux(handler *handlers.Handler) *DynamicMux {
+	return &DynamicMux{
+		routes:     make(map[string]http.HandlerFunc),
+		handler:    handler,
+		middleware: make([]func(http.HandlerFunc) http.HandlerFunc, 0),
+	}
+}
+
+func (dmux *DynamicMux) HandleFunc(pattern string, handler http.HandlerFunc) {
+	dmux.mutex.Lock()
+	defer dmux.mutex.Unlock()
+
+	dmux.routes[pattern] = handler
+}
+
+func (dmux *DynamicMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	dmux.mutex.RLock()
+	pattern := fmt.Sprintf(PatternString, r.Method, r.URL.Path)
+	handler, exists := dmux.routes[pattern]
+	dmux.mutex.RUnlock()
+
+	if !exists {
+		http.NotFound(w, r)
+		return
+	}
+	handler(w, r)
+}
+
+func (dmux *DynamicMux) RegisterWebhook(webhook types.Webhook) {
+	pattern := fmt.Sprintf(PatternString, webhook.Method, webhook.Path)
+	dmux.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
+		dmux.handler.HandleMessage(w, r, webhook)
+	})
+}
+
+// Use adds methods to append to middleware
+func (dmux *DynamicMux) Use(middleware ...func(http.HandlerFunc) http.HandlerFunc) {
+	dmux.middleware = append(dmux.middleware, middleware...)
+}
+
+// Apply middleware to a handler
+func (dmux *DynamicMux) applyMiddleware(handler http.HandlerFunc) http.HandlerFunc {
+	// Reverse order so the first middleware in the chain is the outermost wrapper
+	for i := len(dmux.middleware) - 1; i >= 0; i-- {
+		handler = dmux.middleware[i](handler)
+	}
+	return handler
+}
+
+func RegisterRoutes(handler *handlers.Handler) (*DynamicMux, error) {
+	dmux := NewDynamicMux(handler)
+
+	// Register static routes
+	dmux.HandleFunc("POST /webhooks", handler.CreateWebhook)
+	dmux.HandleFunc("GET /webhooks", handler.GetWebhooks)
+	dmux.HandleFunc("GET /webhooks/{name}/content", handler.GetWebhookContent)
+	dmux.HandleFunc("DELETE /webhooks/{name}", handler.DeleteWebhook)
+	dmux.HandleFunc("DELETE /webhooks/{name}/content", handler.DeleteWebhookContents)
+
+	// Register existing webhooks
 	var webhooks []types.Webhook
 	webhooks, err := handler.Services.DB.GetWebhooks(context.Background())
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	for _, webhook := range webhooks {
-		pattern := fmt.Sprintf("%s %s", webhook.Method, webhook.Path)
-		mux.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
-			handler.HandleMessage(w, r, webhook)
-		})
+		dmux.RegisterWebhook(webhook)
 	}
 
-	return nil
+	return dmux, nil
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -9,3 +9,10 @@ type Webhook struct {
 	ForwardTo       string `json:"forward_to"`
 	PreservePayload bool   `json:"preserve_payload"`
 }
+
+// WebhookRegistrar defines methods for registering webhooks.
+type WebhookRegistrar interface {
+	RegisterWebhook(webhook Webhook)
+}
+
+type MuxContextKey string

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -16,3 +16,4 @@ type WebhookRegistrar interface {
 }
 
 type MuxContextKey string
+type UrlParamContextKey string

--- a/scripts/database/schema.sql
+++ b/scripts/database/schema.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS webhooks;
+CREATE TABLE IF NOT EXISTS webhooks
+(
+    name             VARCHAR(255) NOT NULL PRIMARY KEY,
+    path             VARCHAR(255) NOT NULL,
+    method           VARCHAR(10)  NOT NULL,
+    description      VARCHAR(255),
+    jq_filter        TEXT,
+    forward_to       TEXT,
+    preserve_payload BOOLEAN
+);


### PR DESCRIPTION
- new endpoints can be registered, and are accessible.

Before merging there is some weird behaviour going on:

```go
dmux.HandleFunc("POST /webhooks", handler.CreateWebhook)
dmux.HandleFunc("GET /webhooks", handler.GetWebhooks)
dmux.HandleFunc("GET /webhooks/{name}/content", handler.GetWebhookContent)
dmux.HandleFunc("DELETE /webhooks/{name}", handler.DeleteWebhook)
dmux.HandleFunc("DELETE /webhooks/{name}/content", handler.DeleteWebhookContents)
```

Given the above:
- Calls to `POST /webhooks` and `GET /webhooks` work (they have no pattern matching).
- Calls to `GET /webhooks/{name}/content` return a 404 (hsa pattern matching, suspicious).

Needs to be investigated